### PR TITLE
Pass character-name-history as a symbol to ido.

### DIFF
--- a/ucs-utils.el
+++ b/ucs-utils.el
@@ -1591,7 +1591,7 @@ run as all completion candidates are pre-generated."
                   prompt
                   (remove-if #'(lambda (x)
                                  (and ucs-utils-hide-numbered-cjk-ideographs (string-match-p "_Ideograph[_-][0-9a-fA-F]+\\'" x)))
-                             (ucs-utils-all-prettified-names 'progress)) nil nil nil character-name-history)))
+                             (ucs-utils-all-prettified-names 'progress)) nil nil nil 'character-name-history)))
       (when (string-match-p "\\`[0-9a-fA-F]+\\'" input)
         (callf2 concat "#x" input))
       (if (string-match-p "\\`#" input)


### PR DESCRIPTION
This needs to be a symbol specifying a dynamically-scoped variable.
Unlike passing the history as a value (i.e. nil), it makes the argument
a "place" where new history entries can be assigned.
